### PR TITLE
(wip) add oauth support

### DIFF
--- a/lib/auth.sh
+++ b/lib/auth.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# this script will handle authentication via Oauth
+# see https://docs.snyk.io/snyk-api/snyk-apps


### PR DESCRIPTION
[SUP-1942] Adds OAuth support to the plugin, to avoid the need to source an API token from the environment.