### PR TITLE
Refactor Plugin Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here are a few examples of using the plugin to scan within your Buildkite pipeli
 ```yaml
 steps:
   - label: "🔎 Scanning with Snyk"
+    command: "test.sh"
     plugins:
       - snyk#v0.1.0:
           scan: 'oss'
@@ -52,6 +53,7 @@ steps:
 ```yaml
 steps:
   - label: "🔎 Scanning code with Snyk"
+    command: "test.sh"
     plugins:
       - snyk#v0.1.0:
           scan: 'code'
@@ -64,6 +66,7 @@ Scanning a docker container image by image name and tag:
 ```yaml
 steps:
   - label: "🔎 Scanning container image with Snyk"
+    command: "build.sh"
     plugins:
       - snyk#v0.1.0:
           scan: 'container'
@@ -77,6 +80,7 @@ Block a build when a vulnerability is detected:
 ```yaml
 steps:
   - label: "🔎 Blocking snyk scan"
+    command: "test.sh"
     plugins:
       - snyk#v0.1.0:
           scan: 'oss'
@@ -96,10 +100,6 @@ You can use the [bk cli](https://github.com/buildkite/cli) to run the [pipeline]
 ```bash
 bk local run
 ```
-
-## 👩‍💻 Contributing
-
-Your policy on how to contribute to the plugin!
 
 ## 📜 License
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/snyk.sh
+. "$DIR/../lib/snyk.sh"
+
+# set up the environment
+configure_plugin
+
+#run the scan
+snyk_scan
+

--- a/lib/auth.sh
+++ b/lib/auth.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-# this script will handle authentication via Oauth
-# see https://docs.snyk.io/snyk-api/snyk-apps

--- a/tests/snyk.bats
+++ b/tests/snyk.bats
@@ -25,7 +25,7 @@ setup() {
   unset BUILDKITE_PLUGIN_SNYK_TOKEN_ENV
   unset SNYK_TOKEN
 
-  run "$PWD"/hooks/command
+  run "$PWD"/hooks/post-command
 
   assert_failure
   assert_output --partial 'No token set'
@@ -50,7 +50,7 @@ setup() {
   "artifact upload ${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_NUMBER}-oss.html : exit 0" \
   "annotate \* \* \* \* \* : exit 0"
 
-  run "$PWD"/hooks/command
+  run "$PWD"/hooks/post-command
 
   assert_success
   assert_output --partial 'Scanning OSS'
@@ -66,7 +66,7 @@ setup() {
   stub snyk \
    "code test --json-file-output=${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_NUMBER}-snyk-code.json : echo 'Scanning Code'"
 
-  run "$PWD"/hooks/command
+  run "$PWD"/hooks/post-command
 
   assert_success
   assert_output --partial 'Scanning Code'
@@ -87,7 +87,7 @@ setup() {
   "artifact upload ${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BUILD_NUMBER}-container.html : exit 0" \
   "annotate \* \* \* \* \* : exit 0"
 
-  run "$PWD"/hooks/command
+  run "$PWD"/hooks/post-command
 
   assert_success
   assert_output --partial 'Scanning Container llama'


### PR DESCRIPTION
The plugin initially made use of a command hook, which would overwrite any commands set in a step where the plugin would be configured. This will change the behaviour of the plugin to use a post-command hook, which will allow it to be used in many more scenarios.